### PR TITLE
Use hard links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ then the resulting directory structure will be:
 
 ```text
 bear_sync_folder/
+├── .raw_notes/
+|   ├── 1.md
 ├── tag/
 |   ├── My Bear Document.md
 │   ├── subtag/
@@ -50,6 +52,8 @@ bear_sync_folder/
 ├── tag2/
 |   ├── My Bear Document.md
 ```
+
+Note: only the file under `.raw_notes/` stores data, the remaining files are [hard links](https://en.wikipedia.org/wiki/Hard_link) to the original file.
 
 ## Example - using bear-sync with git
 

--- a/bear_sync/sync.py
+++ b/bear_sync/sync.py
@@ -58,7 +58,7 @@ class BearDB:
         query = """
         SELECT
             Z_5TAGS.Z_5NOTES AS note_id,
-            ZSFNOTETAG.ZTITLE AS tag,
+            ZSFNOTETAG.ZTITLE AS tag
         FROM
             Z_5TAGS
         LEFT JOIN
@@ -96,8 +96,8 @@ class BearDB:
                     f.write(text)
                 id_to_raw_note[note_id] = RawNote(
                     raw_path=note_path,
-                    title=title,
-                    text=text or "untitled",
+                    title=title.removeprefix(".") or "untitled",
+                    text=text,
                     creation_date=self.__core_date_time_to_datetime(creation_date),
                     modification_date=self.__core_date_time_to_datetime(
                         modification_date
@@ -114,13 +114,15 @@ class BearDB:
         # group notes by tag and title
         notes = defaultdict(list)
         for note_id, tag in raw_tags + untagged_notes:
-            notes[(tag, title)].append(note_id)
+            # ignore trashed notes
+            if note_id in id_to_raw_note:
+                notes[(tag, title)].append(note_id)
 
         # notes with the same tag and title are ordered by creation date
         notes_synced = 0
         notes_skipped = 0
         for (tag, title), note_ids in notes.items():
-            note_dir = note_path / tag
+            note_dir = base_path / tag
 
             os.makedirs(note_dir, exist_ok=True)
             for i, note_id in enumerate(note_ids):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,22 @@ readme="README.md"
 
 [project.scripts]
 bear-sync = "bear_sync.main:main"
+
+[tool.bumpver]
+current_version = "0.0.1"
+version_pattern = "MAJOR.MINOR.PATCH"
+commit_message = "bump version {old_version} -> {new_version}"
+tag_message = "{new_version}"
+tag_scope = "default"
+pre_commit_hook = ""
+post_commit_hook = ""
+commit = true
+tag = true
+push = true
+
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+    'current_version = "{version}"',
+    'version = "{version}"',
+]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ find = {}
 
 [project]
 name = "bear-sync"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
     "click>=8.1.8",
     'importlib-metadata; python_version>="3.12"',
@@ -19,7 +19,7 @@ readme="README.md"
 bear-sync = "bear_sync.main:main"
 
 [tool.bumpver]
-current_version = "0.0.1"
+current_version = "0.1.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"


### PR DESCRIPTION
# Changes
- [x] use `.raw_notes/` folder to store actual note data
- [x] use `os.link()` to create hard links to all notes
- [x] strip `.` from the start of note tags and titles
- [x] update readme
- [x] add versioning
