### PR TITLE
Truncate (too) long filenames

### DIFF
--- a/bear_sync/sync.py
+++ b/bear_sync/sync.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import sqlite3
 from collections import defaultdict
@@ -25,8 +26,32 @@ DEFAULT_DB_PATH = (
 )
 
 
-class BearDB:
+def truncate_filename(filename: str, max_length: int = 255) -> str:
+    """
+    Truncate filename to fit macOS filesystem limits (255 bytes).
+    Assumes filename always ends with .md extension.
+    Adds a hash for uniqueness if truncated.
+    """
+    if len(filename.encode("utf-8")) <= max_length:
+        return filename
 
+    hash_length = 8
+    reserved_length = 3 + hash_length + 1  # .md + hash + underscore
+    available_bytes = max_length - reserved_length
+
+    name = filename[:-3]  # remove .md
+    name_hash = hashlib.md5(filename.encode()).hexdigest()[:hash_length]
+
+    # errors='ignore' drops incomplete UTF-8 sequences that may occur when
+    # byte truncation cuts through multi-byte characters (like emojis)
+    truncated_name = name.encode("utf-8")[:available_bytes].decode(
+        "utf-8", errors="ignore"
+    )
+
+    return f"{truncated_name}_{name_hash}.md"
+
+
+class BearDB:
     def __init__(self, db_path: Path):
         self.con = sqlite3.connect(db_path)
         self.cursor = self.con.cursor()
@@ -138,6 +163,7 @@ class BearDB:
                     suffix = f"_{i}"
 
                 file_name = f"{note.title.replace('/', '_')}{suffix}.md"
+                file_name = truncate_filename(file_name)
                 file_path = note_dir / file_name
 
                 if file_path.exists():


### PR DESCRIPTION
Not sure if you like pull requests or even the code proposed here, but I thought I'd post in case anything finds it useful.

I ran into this error the first time I ran `bear-sync`:

```
Traceback (most recent call last):
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/bin/bear-sync", line 12, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/bear_sync/main.py", line 28, in main
    sync(
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/bear_sync/sync.py", line 176, in sync
    db.save_notes(Path(output_path), overwrite)
  File "/Users/askielboe/.cache/uv/archive-v0/DkU_i6tPjPDA3bxx9HK6_/lib/python3.12/site-packages/bear_sync/sync.py", line 143, in save_notes
    if file_path.exists():
       ^^^^^^^^^^^^^^^^^^
  File "/Users/askielboe/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/pathlib.py", line 860, in exists
    self.stat(follow_symlinks=follow_symlinks)
  File "/Users/askielboe/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/pathlib.py", line 840, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 63] File name too long: '/Users/askielboe/Databases/Bear/untagged/Iain M. Bank\'s Culture is perhaps my favourite example of a "working" communist society - but it does rely on "magic" technology, engineering of its inhabitants to be nicer and ultimately on god-like AIs to actually run things. Most humans in the stories are effectively pets of the AIs - pets who are very well looked after, and who can leave the Culture if they want (which the vast majority don\'t - of course) but where they don\'t really matter._372.md'
```

Instead of fixing my exorbitant note titles I thought I'd just truncate it..